### PR TITLE
use the correct constructor for v4

### DIFF
--- a/acf-ninja-forms-field-v4.php
+++ b/acf-ninja-forms-field-v4.php
@@ -229,4 +229,4 @@ class acf_field_ninja_forms extends acf_field {
 }
 
 // create field
-new acf_field_FIELD_NAME();
+new acf_field_ninja_forms();


### PR DESCRIPTION
The plugin was previously not working in ACF 4.x - no Ninja Forms field type was showing up when creating field groups in ACF. 

It looks like the issue there was a placeholder constructor name. Calling the correct name of the class (`new acf_field_ninja_forms();`) brings the plugin to life in ACF 4.x once again.
